### PR TITLE
Introduce optional paramaters

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,7 @@ TBD: generic URL of yaml files
 
 TBD: change version
 
+TBD: document optional public_master_hostname and openshift_master_default_subdomain
+
 ## Authors
 - Marek Libra

--- a/pkg/apis/kubevirt/v1alpha1/kwebui_types.go
+++ b/pkg/apis/kubevirt/v1alpha1/kwebui_types.go
@@ -14,6 +14,9 @@ type KWebUISpec struct {
 	RegistryUrl string `json:"registry_url,omitempty"`	// the registry for docker image (ie.: quay.io)
 	RegistryNamespace string `json:"registry_namespace,omitempty"` // i.e. "kubevirt"
 
+	OpenshiftMasterDefaultSubdomain string `json:"openshift_master_default_subdomain,omitempty"` // optional - workaround if openshift-console is not deployed, otherwise auto-discovered from its ConfigMap
+	PublicMasterHostname string `json:"public_master_hostname,omitempty"` // optional - workaround if openshift-console is not deployed, otherwise auto-discovered from its ConfigMap
+
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 }

--- a/pkg/controller/kwebui/kwebui_controller.go
+++ b/pkg/controller/kwebui/kwebui_controller.go
@@ -273,7 +273,6 @@ func generateInventory(instance *kubevirtv1alpha1.KWebUI, namespace string, acti
 	}
 	defer f.Close()
 
-	// TODO: provide parameters if openshift-console project is not present
 	f.WriteString("[OSEv3:children]\nmasters\n\n")
 	f.WriteString("[OSEv3:vars]\n")
 	f.WriteString("platform=openshift\n")
@@ -284,6 +283,12 @@ func generateInventory(instance *kubevirtv1alpha1.KWebUI, namespace string, acti
 	f.WriteString(strings.Join([]string{"kubevirt_web_ui_namespace=", def(namespace, "kubevirt-web-ui"), "\n"}, ""))
 	if action == "deprovision" {
 		f.WriteString("preserve_namespace=true\n")
+	}
+	if instance.Spec.OpenshiftMasterDefaultSubdomain != "" {
+		f.WriteString(fmt.Sprintf("openshift_master_default_subdomain=%s\n", instance.Spec.OpenshiftMasterDefaultSubdomain))
+	}
+	if instance.Spec.PublicMasterHostname != "" {
+		f.WriteString(fmt.Sprintf("public_master_hostname=%s\n", instance.Spec.PublicMasterHostname))
 	}
 	f.WriteString("\n")
 	f.WriteString("[masters]\n")


### PR DESCRIPTION
`public_master_hostname` and `openshift_master_default_subdomain`

These parameters are used to workaround potentially missing openshift-console deployment.
If the deployment exists, these parameters are automatically read from ots ConfigMap.