### PR TITLE
CR: provided version is prefixed with 'v'

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To actually deploy the Kubevirt Web UI, choose it's version by editting `spec.ve
 Example:
 ```angular2
 spec:
-  version: "1.4.0-4"
+  version: "v1.4.0-9"
 ``` 
 
 The image repository can be farther tweaked by using the `spec.registry_url` and `spec.registry_namespace` parameters. 

--- a/build/kubevirt-web-ui-ansible/roles/kubevirt_web_ui/tasks/required_params.yml
+++ b/build/kubevirt-web-ui-ansible/roles/kubevirt_web_ui/tasks/required_params.yml
@@ -4,7 +4,7 @@
 - set_fact: kubevirt_web_ui_image_tag="v1.3.0"
   when: version is defined and "0.9." in version
 
-- set_fact: kubevirt_web_ui_image_tag="v{{ docker_tag }}"
+- set_fact: kubevirt_web_ui_image_tag="{{ docker_tag }}"
   when: docker_tag is defined
 
 - set_fact: kubevirt_web_ui_image_name="{{ registry_url }}/{{ registry_namespace }}/kubevirt-web-ui:{{ kubevirt_web_ui_image_tag | default("latest")}}"

--- a/deploy/crds/kubevirt_v1alpha1_kwebui_cr.yaml
+++ b/deploy/crds/kubevirt_v1alpha1_kwebui_cr.yaml
@@ -3,7 +3,7 @@ kind: KWebUI
 metadata:
   name: kubevirt-web-ui
 spec:
-  version: "1.4.0-9"
+  version: "v1.4.0-9"
   registry_url: "quay.io"
   registry_namespace: "kubevirt"
   branding: "okdvirt"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
         - name: kubevirt-web-ui-operator
           securityContext:
             runAsUser: 0
-          image: quay.io/kubevirt/kubevirt-web-ui-operator:latest
+          image: quay.io/kubevirt/kubevirt-web-ui-operator:v1.4.0
           ports:
           - containerPort: 60000
             name: metrics

--- a/pkg/controller/kwebui/provision.go
+++ b/pkg/controller/kwebui/provision.go
@@ -37,7 +37,7 @@ func ReconcileExistingDeployment(r *ReconcileKWebUI, request reconcile.Request, 
 			// quay.io/kubevirt/kubevirt-web-ui:v1.4
 			existingVersion = AfterLast(container.Image, ":")
 			log.Info(fmt.Sprintf("Existing image tag: %s, from image: %s", existingVersion, container.Image))
-			existingVersion = strings.TrimPrefix(existingVersion, "v")
+			// existingVersion = strings.TrimPrefix(existingVersion, "v")
 			if existingVersion == "" {
 				log.Info("Failed to read existing image tag")
 				return reconcile.Result{}, stderrors.New("failed to read existing image tag")
@@ -46,7 +46,7 @@ func ReconcileExistingDeployment(r *ReconcileKWebUI, request reconcile.Request, 
 		}
 	}
 
-	// TODO: reconcile based on other parameters, not only the Version
+	// TODO: reconcile based on other parameters, not only on the Version
 
 	if existingVersion == "" {
 		log.Info("Can not read deployed container version, giving up.")


### PR DESCRIPTION
So kubevirt-ansible's `docker_tag` can be easily reused.