### PR TITLE
Add V2VVMWare CRD during web-ui deployment

### DIFF
--- a/build/kubevirt-web-ui-ansible/roles/kubevirt_web_ui/defaults/main.yml
+++ b/build/kubevirt-web-ui-ansible/roles/kubevirt_web_ui/defaults/main.yml
@@ -10,6 +10,7 @@ kubevirt_web_ui_nodeselector: {}
 
 __console_template_file: "console-template.yaml"
 __console_config_file: "console-config.yaml"
+__v2vvmware_crd_file: "{{ role_path }}/files/kubevirt_v1alpha1_v2vvmware_crd.yaml"
 
 # Default the replica count to the number of masters.
 kubevirt_web_ui_replica_count: "1"

--- a/build/kubevirt-web-ui-ansible/roles/kubevirt_web_ui/files/kubevirt_v1alpha1_v2vvmware_crd.yaml
+++ b/build/kubevirt-web-ui-ansible/roles/kubevirt_web_ui/files/kubevirt_v1alpha1_v2vvmware_crd.yaml
@@ -1,0 +1,15 @@
+---
+# source: https://github.com/oVirt/v2v-conversion-host/blob/master/kubevirt-vmware/deploy/crds/kubevirt_v1alpha1_v2vvmware_crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: v2vvmwares.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: V2VVmware
+    listKind: V2VVmwareList
+    plural: v2vvmwares
+    singular: v2vvmware
+  scope: Namespaced
+  version: v1alpha1

--- a/build/kubevirt-web-ui-ansible/roles/kubevirt_web_ui/tasks/deprovision.yml
+++ b/build/kubevirt-web-ui-ansible/roles/kubevirt_web_ui/tasks/deprovision.yml
@@ -1,4 +1,9 @@
 ---
+# TODO: for fail-recovery scenarios, delete the objects bellow conditionally - just if they exist
+
+- name: Remove V2VVMWare Custom Resource Definition
+  shell: "{{ openshift_client_binary }} delete -f {{ __v2vvmware_crd_file }} || true"
+
 - name: Remove Kubevirt Web UI OAuth client
   shell: "{{ openshift_client_binary }} delete oauthclient kubevirt-web-ui"
 

--- a/build/kubevirt-web-ui-ansible/roles/kubevirt_web_ui/tasks/provision.yml
+++ b/build/kubevirt-web-ui-ansible/roles/kubevirt_web_ui/tasks/provision.yml
@@ -75,6 +75,9 @@
     --param TLS_CA_CERT="{{ console_ca_cert | default('') }}"
     | {{ openshift_client_binary }} apply -f -
 
+- name: Add V2VVmware Custom Resource Definition
+  shell: "{{ openshift_client_binary }} apply -f {{ __v2vvmware_crd_file }}"
+
 - name: Remove temp directory
   file:
     state: absent


### PR DESCRIPTION
Required for the V2V flow.

Source: https://github.com/oVirt/v2v-conversion-host/blob/master/kubevirt-vmware/deploy/crds/kubevirt_v1alpha1_v2vvmware_crd.yaml