### PR TITLE
Generate CSV for KubeVirt Web UI Operator

### DIFF
--- a/deploy/olm-catalog/kubevirt-web-ui-operator/0.1.1/kubevirt-web-ui-operator.v0.1.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-web-ui-operator/0.1.1/kubevirt-web-ui-operator.v0.1.1.clusterserviceversion.yaml
@@ -1,0 +1,171 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"kubevirt.io/v1alpha1","kind":"KWebUI","metadata":{"name":"kubevirt-web-ui"},"spec":{"branding":"okdvirt","imagePullPolicy":"Always","registry_namespace":"kubevirt","registry_url":"quay.io","version":"v0.1.1"}}]'
+    capabilities: Basic Install
+    categories: OpenShift Optional
+    containerImage: quay.io/kubevirt/kubevirt-web-ui-operator
+    createdAt: '2019-04-18T21:00:00Z'
+    description: KubeVirt Web UI
+    repository: https://github.com/kubevirt/kubevirt-web-ui-operator
+  name: kubevirt-web-ui-operator.v0.1.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: KubeVirt Web UI
+      displayName: KubeVirt Web UI Resource
+      kind: KWebUI
+      name: kwebuis.kubevirt.io
+      version: v1alpha1
+  description: KubeVirt Web UI
+  displayName: Web Ui Operator
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - oauth.openshift.io
+          - apiextensions.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          verbs:
+          - '*'
+        serviceAccountName: kubevirt-web-ui-operator
+      deployments:
+      - name: kubevirt-web-ui-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: kubevirt-web-ui-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: kubevirt-web-ui-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: kubevirt-web-ui-operator
+                image: quay.io/kubevirt/kubevirt-web-ui-operator:v0.1.1
+                imagePullPolicy: Always
+                name: kubevirt-web-ui-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                readinessProbe:
+                  exec:
+                    command:
+                    - stat
+                    - /tmp/operator-sdk-ready
+                  failureThreshold: 1
+                  initialDelaySeconds: 4
+                  periodSeconds: 10
+                resources: {}
+              serviceAccountName: kubevirt-web-ui-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - replicationcontrollers
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - extensions
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - kubevirt.io
+          - template.openshift.io
+          - route.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: kubevirt-web-ui-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - KubeVirt
+  - Virtualization
+  - UI
+  labels:
+    alm-owner-kubevirt: kubevirt-web-ui
+    operated-by: kubevirt-web-ui
+  links:
+  - name: KubeVirt
+    url: https://kubevirt.io
+  - name: Source Code
+    url: https://github.com/kubevirt/web-ui-operator
+  maintainers:
+  - email: kubevirt-dev@googlegroups.com
+    name: KubeVirt project
+  maturity: alpha
+  provider:
+    name: KubeVirt project
+  selector:
+    matchLabels:
+      alm-owner-kubevirt: kubevirt-web-ui
+      operated-by: kubevirt-web-ui
+  version: 0.1.1

--- a/deploy/olm-catalog/kubevirt-web-ui-operator/0.1.1/kubevirt_v1alpha1_kwebui_crd.yaml
+++ b/deploy/olm-catalog/kubevirt-web-ui-operator/0.1.1/kubevirt_v1alpha1_kwebui_crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kwebuis.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KWebUI
+    listKind: KWebUIList
+    plural: kwebuis
+    singular: kwebui
+  scope: Namespaced
+  version: v1alpha1

--- a/deploy/olm-catalog/kubevirt-web-ui-operator/kubevirt-web-ui-package.yaml
+++ b/deploy/olm-catalog/kubevirt-web-ui-operator/kubevirt-web-ui-package.yaml
@@ -1,0 +1,4 @@
+packageName: kubevirt-web-ui
+channels:
+  - name: alpha
+    currentCSV: kubevirt-web-ui-operator.v0.1.1

--- a/hack/make-olm.sh
+++ b/hack/make-olm.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+PROJECT_ROOT="$(readlink -e $(dirname "$BASH_SOURCE[0]")/../)"
+CSV_VERSION="${CSV_VERSION:-0.0.0}"
+CATALOG_DIR="${PROJECT_ROOT}/deploy/olm-catalog"
+PACKAGE_DIR="${CATALOG_DIR}/kubevirt-web-ui-operator"
+BUNDLE_DIR="${PACKAGE_DIR}/${CSV_VERSION}"
+
+which operator-sdk &> /dev/null || {
+	echo "operator-sdk not found (see https://github.com/operator-framework/operator-sdk)"
+	exit 1
+}
+
+which operator-courier &> /dev/null || {
+	echo "operator-courier not found (see https://github.com/operator-framework/operator-courier)"
+	exit 2
+}
+
+operator-sdk olm-catalog gen-csv --csv-version ${CSV_VERSION} --update-crds
+
+# Create package directory if it doesn't exist
+mkdir -p "${PACKAGE_DIR}"
+rm -rf "${BUNDLE_DIR}"
+cat << EOF > ${PACKAGE_DIR}/kubevirt-web-ui-package.yaml
+packageName: kubevirt-web-ui
+channels:
+  - name: alpha
+    currentCSV: kubevirt-web-ui-operator.v${CSV_VERSION}
+EOF
+
+# Correct operator-sdk naming
+mv "${CATALOG_DIR}/web-ui-operator/${CSV_VERSION}" "${BUNDLE_DIR}"
+rmdir "${CATALOG_DIR}/web-ui-operator"
+
+python3 "${PROJECT_ROOT}/hack/update-olm.py" \
+	"${BUNDLE_DIR}/web-ui-operator.v${CSV_VERSION}.clusterserviceversion.yaml" > \
+	"${BUNDLE_DIR}/kubevirt-web-ui-operator.v${CSV_VERSION}.clusterserviceversion.yaml"
+rm "${BUNDLE_DIR}/web-ui-operator.v${CSV_VERSION}.clusterserviceversion.yaml"
+
+sed -i "s|latest|v${CSV_VERSION}|g" "${BUNDLE_DIR}/kubevirt-web-ui-operator.v${CSV_VERSION}.clusterserviceversion.yaml"
+
+cp "${PACKAGE_DIR}/kubevirt-web-ui-package.yaml" "${BUNDLE_DIR}/kubevirt-web-ui-package.yaml"
+operator-courier verify --ui_validate_io ${BUNDLE_DIR} && echo "OLM verify passed" || echo "OLM verify failed"
+rm "${BUNDLE_DIR}/kubevirt-web-ui-package.yaml"

--- a/hack/update-olm.py
+++ b/hack/update-olm.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+import logging
+import sys
+import yaml
+
+_DESCRIPTION = "KubeVirt Web UI"
+_ANNOTATIONS = {
+    'categories': 'OpenShift Optional',
+    'capabilities': 'Basic Install',
+    'containerImage': 'quay.io/kubevirt/kubevirt-web-ui-operator',
+    'repository': 'https://github.com/kubevirt/kubevirt-web-ui-operator',
+    'createdAt': '2019-04-18T21:00:00Z',
+    'description': _DESCRIPTION,
+}
+_SPEC = {
+    'description': _DESCRIPTION,
+    'provider': {
+        'name': 'KubeVirt project'
+    },
+    'maintainers': [{
+        'name': 'KubeVirt project',
+        'email': 'kubevirt-dev@googlegroups.com',
+    }],
+    'keywords': [
+        'KubeVirt', 'Virtualization', 'UI'
+    ],
+    'links': [{
+        'name': 'KubeVirt',
+        'url': 'https://kubevirt.io',
+    }, {
+        'name': 'Source Code',
+        'url': 'https://github.com/kubevirt/web-ui-operator'
+    }],
+    'labels': {
+        'alm-owner-kubevirt': 'kubevirt-web-ui',
+        'operated-by': 'kubevirt-web-ui',
+    },
+    'selector': {
+        'matchLabels': {
+            'alm-owner-kubevirt': 'kubevirt-web-ui',
+            'operated-by': 'kubevirt-web-ui',
+        },
+    },
+}
+
+_CRD_INFOS = {
+    'kwebuis.kubevirt.io': {
+        'displayName': 'KubeVirt Web UI Resource',
+        'description': _DESCRIPTION,
+    }
+}
+
+
+def process(path):
+    with open(path, 'rt') as fh:
+        manifest = yaml.safe_load(fh)
+
+    manifest['metadata']['name'] = 'kubevirt-' + manifest['metadata']['name']
+    manifest['metadata']['annotations'].update(_ANNOTATIONS)
+
+    manifest['spec'].update(_SPEC)
+
+    for crd in manifest['spec']['customresourcedefinitions']['owned']:
+        crd.update(_CRD_INFOS.get(crd['name'], {}))
+
+    yaml.safe_dump(manifest, sys.stdout)
+
+
+if __name__ == '__main__':
+    for arg in sys.argv[1:]:
+        try:
+            process(arg)
+        except Exception as ex:
+            logging.error('error processing %r: %s', arg, ex)
+# keep going!


### PR DESCRIPTION
Use operator-sdk to generate the CSV and operator-courier to test the
CSV. This makes it possible to, on release, simply run
`CSV_VERSION=0.1.1 ./hack/make-olm.sh` and generate a CSV that ties the
CSV to the operator version.