### PR TITLE
Grant cluster-wide kubevirt.io API access to operator's SA

### DIFF
--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -241,6 +241,7 @@ func GetClusterRole() *rbacv1.ClusterRole {
 					"oauth.openshift.io",
 					"apiextensions.k8s.io",
 					"kubevirt.io",
+					"extensions",
 				},
 				Resources: []string{
 					"*",

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -240,6 +240,7 @@ func GetClusterRole() *rbacv1.ClusterRole {
 				APIGroups: []string{
 					"oauth.openshift.io",
 					"apiextensions.k8s.io",
+					"kubevirt.io",
 				},
 				Resources: []string{
 					"*",


### PR DESCRIPTION
The operator is not namespaced anymore.