### PR TITLE
s/apply/create in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ oc apply -f role.yaml
 
 oc apply -f role_binding.yaml
 
-oc apply -f crds/kubevirt_v1alpha1_kwebui_crd.yaml
+oc create -f crds/kubevirt_v1alpha1_kwebui_crd.yaml
 oc apply -f operator.yaml
 ```
 
@@ -51,7 +51,7 @@ oc apply -f service_account.yaml
 oc apply -f role.yaml
 oc apply -f role_binding.yaml
 
-oc apply -f crds/kubevirt_v1alpha1_kwebui_crd.yaml
+oc create -f crds/kubevirt_v1alpha1_kwebui_crd.yaml
 oc apply -f operator.yaml
 ```
 


### PR DESCRIPTION
`apply` doesn't work, but `create` does.
```
# oc apply -f crds/kubevirt_v1alpha1_kwebui_crd.yaml
Warning: oc apply should be used on resource created by either oc create --save-config or oc apply
The CustomResourceDefinition "kwebuis.kubevirt.io" is invalid: spec.scope: Invalid value: "Namespaced": field is immutable
# oc create -f crds/kubevirt_v1alpha1_kwebui_crd.yaml
customresourcedefinition.apiextensions.k8s.io/kwebuis.kubevirt.io created
# oc apply -f operator.yaml
deployment.apps/kubevirt-web-ui-operator created
# oc get pods -n kubevirt-web-ui
NAME                                        READY   STATUS              RESTARTS   AGE
console-6f4c5fb8fd-4d62b                    1/1     Running             0          65m
console-6f4c5fb8fd-mwdc7                    1/1     Running             0          65m
kubevirt-web-ui-operator-7d5ff9d9db-snlb5   0/1     ContainerCreating   0          17s
```
